### PR TITLE
Feature, Resource-based privileges

### DIFF
--- a/mysql-schema/025-privilege-resources.sql
+++ b/mysql-schema/025-privilege-resources.sql
@@ -1,0 +1,12 @@
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+INSERT INTO changelog VALUES (25, UNIX_TIMESTAMP());
+
+ALTER TABLE user_privileges
+  CHANGE COLUMN privilege scope VARCHAR(50) NOT NULL;
+
+ALTER TABLE user_privileges
+  ADD COLUMN resource VARCHAR(255) NOT NULL DEFAULT '*' AFTER user_id;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,7 +1422,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -1451,7 +1451,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"

--- a/src/privilege/service.ts
+++ b/src/privilege/service.ts
@@ -1,12 +1,13 @@
 import db from '../database';
 import { User } from '../user/types';
+import { PrivilegeMap } from './types';
 
 type PrivilegeRow = {
   resource: string,
   scope: string,
 };
 
-export async function getPrivilegesForUser(user: User): Promise<any> {
+export async function getPrivilegesForUser(user: User): Promise<PrivilegeMap> {
 
   const query = 'SELECT resource, scope FROM user_privileges WHERE user_id = ?';
   const result = await db.query(query, [user.id]);

--- a/src/privilege/service.ts
+++ b/src/privilege/service.ts
@@ -13,7 +13,7 @@ export async function getPrivilegesForUser(user: User): Promise<any> {
 
   return result[0].reduce( (currentPrivileges: any, row: PrivilegeRow) => {
 
-    let privileges = Object.assign({}, currentPrivileges);
+    const privileges = Object.assign({}, currentPrivileges);
 
     if (privileges.hasOwnProperty(row.resource)) {
       if (privileges[row.resource].indexOf(row.scope) === -1) {
@@ -24,7 +24,7 @@ export async function getPrivilegesForUser(user: User): Promise<any> {
     }
 
     return privileges;
-  
+
   }, {});
 
 }

--- a/src/privilege/service.ts
+++ b/src/privilege/service.ts
@@ -2,26 +2,37 @@ import db from '../database';
 import { User } from '../user/types';
 
 type PrivilegeRow = {
-  privilege: string;
+  resource: string,
+  scope: string,
 };
 
-export async function getPrivilegesForUser(user: User): Promise<string[]> {
+export async function getPrivilegesForUser(user: User): Promise<any> {
 
-  const query = 'SELECT privilege FROM user_privileges WHERE user_id = ?';
+  const query = 'SELECT resource, scope FROM user_privileges WHERE user_id = ?';
   const result = await db.query(query, [user.id]);
 
-  return result[0].map( (row: PrivilegeRow) => {
+  return result[0].reduce( (currentPrivileges: any, row: PrivilegeRow) => {
 
-    return row.privilege;
+    let privileges = Object.assign({}, currentPrivileges);
 
-  });
+    if (privileges.hasOwnProperty(row.resource)) {
+      if (privileges[row.resource].indexOf(row.scope) === -1) {
+        privileges[row.resource].push(row.scope);
+      }
+    } else {
+      privileges[row.resource] = [row.scope];
+    }
+
+    return privileges;
+  
+  }, {});
 
 }
 
-export async function hasPrivilege(user: User, privilege: string): Promise<boolean> {
+export async function hasPrivilege(user: User, scope: string, resource: string): Promise<boolean> {
 
-  const query = 'SELECT id FROM user_privileges WHERE user_id = ? AND privilege = ?';
-  const result = await db.query(query, [user.id, privilege]);
+  const query = 'SELECT id FROM user_privileges WHERE user_id = ? AND scope = ? AND resource = ?';
+  const result = await db.query(query, [user.id, scope, resource]);
 
   return result[0].length === 1;
 

--- a/src/privilege/types.ts
+++ b/src/privilege/types.ts
@@ -1,0 +1,3 @@
+export type PrivilegeMap = {
+  [resource: string]: string[],
+};

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -1,4 +1,5 @@
 import { User, UserType } from '../types';
+import { PrivilegeMap } from '../../privilege/types';
 
 const TypeMap = new Map<UserType, string>([
   [UserType.user, 'user'],
@@ -25,7 +26,7 @@ export function collection(users: User[]) {
 
 }
 
-export function item(user: User, privileges: string[]) {
+export function item(user: User, privileges: PrivilegeMap) {
 
   const hal: any = {
     _links: {

--- a/src/user/formats/hal.ts
+++ b/src/user/formats/hal.ts
@@ -1,5 +1,5 @@
-import { User, UserType } from '../types';
 import { PrivilegeMap } from '../../privilege/types';
+import { User, UserType } from '../types';
 
 const TypeMap = new Map<UserType, string>([
   [UserType.user, 'user'],


### PR DESCRIPTION
### Changes

- Adding a resource column in the `user_privileges` table
- Updating the `privilege` column to `scope` for more clarity since both the scope and resource together make up a privilege now
- Updated some functions to leverage resource in addition to scope
- `getPrivilegesForUser` now returns a map of resource to array of scopes

### Breaking Change

So for this change, the format of the returned privileges object has changed. Before it was a simple array of scopes available to the user that is authorized:
```
['foo', 'bar', 'bar-write']
```

And now it is a map of resources and scopes:
```
{
  '*': ['foo', 'bar'],
  'http://localhost:8000/my/resource': ['bar-write'],
}
```

Where `*` represents any resource. I opted to prefer `*` over `NULL` for both the table column value as well as in the returned map of resources because it ended up unnecessarily complicating things by trying to have `NULL` represent any resource in the data structure, but then convert it to some other identifier in the returned map of privileges.